### PR TITLE
[fix] reset restrictedFields when admin

### DIFF
--- a/services/config.js
+++ b/services/config.js
@@ -35,6 +35,8 @@ const getConfig = async (PostBody = {filter: {}}, user = null) => {
             'environment.overrideSendTo',
             'licence'
         ];
+    } else {
+        queryBuilder.restrictedFields = [];
     }
     const config = await queryBuilder.findOne(PostBody, true);
     if (config.environment) {


### PR DESCRIPTION
Reset restrictedFields when the admin get the config

Explanation : 
- We start Aquila, we get the config **as an Admin**
- Before a `restart` we get the config **as an Admin**
- After the restart we reload the page with an url (created with the `adminPrefix`)

**BUT** If we go to a page in the front, we get the config as an user and `restrictedFields` are placed.

After that, if we get the config as an Admin, the `restrictedFields` **aren't empt**y ! So we get the configuration as a user !
And we don't have the `adminPrefix` and we can't reload the page correctly