### PR TITLE
Use setConfig()

### DIFF
--- a/routes/modules.js
+++ b/routes/modules.js
@@ -19,7 +19,26 @@ module.exports = function (app) {
     app.post('/v2/modules/md',       authentication, adminAuth, getModuleMd);
     app.delete('/v2/modules/:id',    authentication, adminAuth, removeModule);
     app.get('/v2/modules/check',     authentication, adminAuth, checkDependencies);
-    app.put('/v2/module/config/:id',  authentication, adminAuth, setModuleConfigById);
+    app.put('/v2/module/config/:id', authentication, adminAuth, setModuleConfigById); // deprecated -> use /v2/module/setConfig
+    app.post('/v2/module/setConfig',  authentication, adminAuth, setModuleConfig);
+};
+
+/**
+ * Set the config of a module using his name
+ * req.body.name -> the name of the module
+ * req.body.config -> the new config
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ * @param {Function} next
+ * @returns {Object} {config : theNewConfig}
+ */
+const setModuleConfig = async (req, res, next) => {
+    try {
+        const newConfig = await serviceModule.setConfig(req.body.name, req.body.config);
+        return res.json({config: newConfig});
+    } catch (err) {
+        next(err);
+    }
 };
 
 const checkDependencies = async (req, res, next) => {

--- a/services/modules.js
+++ b/services/modules.js
@@ -44,6 +44,7 @@ const getModule = async (PostBody) => {
  * @param body : body of the request, it will update the module configuration
  * @param _id : string : ObjectId of the module configuration has changed
  * @returns return configuration's module
+ * @deprecated
  */
 const setModuleConfigById = async (_id, config) => {
     if (!mongoose.Types.ObjectId.isValid(_id)) throw NSErrors.InvalidObjectIdError;
@@ -854,10 +855,10 @@ const getConfig = async (name) => {
  * @param name {string} module name / code
  * @param newConfig {object} the new configuration
  * @returns {Promise<*>} Returns the new module configuration
- * @deprecated
  */
 const setConfig = async (name, newConfig) => {
-    return Modules.updateOne({name}, {$set: {config: newConfig}}, {new: true});
+    await Modules.updateOne({name}, {$set: {config: newConfig}}, {new: true});
+    return getConfig(name);
 };
 
 /**

--- a/services/modules.js
+++ b/services/modules.js
@@ -20,6 +20,7 @@ const fs               = require('../utils/fsp');
 const NSErrors         = require('../utils/errors/NSErrors');
 const {Modules}        = require('../orm/models');
 const themesService    = require('./themes');
+const aquilaEvents     = require('../utils/aquilaEvents');
 
 const restrictedFields = [];
 const defaultFields    = ['*'];
@@ -857,7 +858,10 @@ const getConfig = async (name) => {
  * @returns {Promise<*>} Returns the new module configuration
  */
 const setConfig = async (name, newConfig) => {
-    await Modules.updateOne({name}, {$set: {config: newConfig}}, {new: true});
+    const configToSave = {config: newConfig};
+    await aquilaEvents.emit(`changePluginConfig_${name}`, configToSave);
+    const correctConfigToSave = configToSave.config || {};
+    await Modules.updateOne({name}, {$set: {config: correctConfigToSave}}, {new: true});
     return getConfig(name);
 };
 


### PR DESCRIPTION
de-depreacted `setConfig(moduleName, newConfig)`

- Add a route POST -> `/v2/module/setConfig`
- Add a custom event when the config is saved
- documentation [here in AquilaCMS doc](https://doc.aquila-cms.com/#/Creating/Plugin/Plugin_Save)
